### PR TITLE
handle our DHCP settings with multiple domains

### DIFF
--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -371,7 +371,7 @@ def main():
         scheduler_module = load_module("nodewatcher.plugins." + config.scheduler)
 
         instance_id = _get_metadata("instance-id")
-        hostname = _get_metadata("local-hostname")
+        hostname = _get_metadata("local-hostname").split()[0]
         instance_type = _get_metadata("instance-type")
         log.info("Instance id is %s, hostname is %s, instance type is %s", instance_id, hostname, instance_type)
         asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config)


### PR DESCRIPTION
our DHCP options in our VPC causes the `local-hostname` metadata to return this:

```
$ wget -qO- http://169.254.169.254/latest/meta-data/local-hostname
ip-172-31-39-217.us-west-2.compute.internal cerebras.aws
```

which nodewatcher does not expect and has been acknowledged as unsupported in aws/aws-parallelcluster#1249

we can work around this by doing a simple split (which also works even if we only returned one domain)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
